### PR TITLE
The most important changes include updating the SDK version to 8.0.0, updating the TargetFramework to net8.0, and updating package versions in multiple projects. Additionally, the Testcontainers.MongoDb package reference was removed from two projects and global usings were updated.

### DIFF
--- a/Global.json
+++ b/Global.json
@@ -1,7 +1,7 @@
 {
-	"sdk": {
-		"version": "7.0.0",
-		"rollForward": "latestMinor",
-		"allowPrerelease": false
-	}
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
 }

--- a/src/CoreBusiness/IssueTracker.CoreBusiness/IssueTracker.CoreBusiness.csproj
+++ b/src/CoreBusiness/IssueTracker.CoreBusiness/IssueTracker.CoreBusiness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
@@ -18,10 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="34.0.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="7.0.10"/>
-		<PackageReference Include="MongoDB.Bson" Version="2.21.0"/>
+		<PackageReference Include="MongoDB.Bson" Version="2.22.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/PlugIns/IssueTracker.PlugIns/IssueTracker.PlugIns.csproj
+++ b/src/PlugIns/IssueTracker.PlugIns/IssueTracker.PlugIns.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
@@ -9,9 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0"/>
-		<PackageReference Include="MongoDB.Driver" Version="2.21.0"/>
-		<PackageReference Include="Testcontainers.MongoDb" Version="3.4.0"/>
+		<PackageReference Include="MongoDB.Driver" Version="2.22.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Services/IssueTracker.Services/IssueTracker.Services.csproj
+++ b/src/Services/IssueTracker.Services/IssueTracker.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
@@ -9,7 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\CoreBusiness\IssueTracker.CoreBusiness\IssueTracker.CoreBusiness.csproj"/>
+	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\CoreBusiness\IssueTracker.CoreBusiness\IssueTracker.CoreBusiness.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/UI/IssueTracker.UI/IssueTracker.UI.csproj
+++ b/src/UI/IssueTracker.UI/IssueTracker.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UserSecretsId>aspnet-IssueTrackerUI-00E08DDA-E837-4DD5-9C9E-429A779DF71A</UserSecretsId>
@@ -25,23 +25,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blazored.SessionStorage" Version="2.4.0"/>
-		<PackageReference Include="JetBrains.Annotations" Version="2023.2.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.Identity.Web" Version="2.13.3"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.Identity.Web.UI" Version="2.13.3"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.7.0"/>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.9"/>
-		<PackageReference Include="Radzen.Blazor" Version="4.15.5"/>
+		<PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
+		<PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="2.13.3" />
+		<PackageReference Include="Microsoft.Identity.Web.UI" Version="2.13.3" />
+		<PackageReference Include="Radzen.Blazor" Version="4.15.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/IssueTracker.CoreBusiness.Tests.Unit/IssueTracker.CoreBusiness.Tests.Unit.csproj
+++ b/tests/IssueTracker.CoreBusiness.Tests.Unit/IssueTracker.CoreBusiness.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -11,15 +11,24 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blazored.SessionStorage" Version="2.3.0" />
-		<PackageReference Include="Blazored.SessionStorage.TestExtensions" Version="2.3.0" />
-		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.10"/>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0"/>
-		<PackageReference Include="Moq" Version="4.20.69"/>
-		<PackageReference Include="NSubstitute" Version="5.0.0" />
-		<PackageReference Include="xunit" Version="2.5.0"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+		<PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
+		<PackageReference Include="Blazored.SessionStorage.TestExtensions" Version="2.4.0" />
+		<PackageReference Include="bunit.core" Version="1.25.3" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+		<PackageReference Include="Moq" Version="4.20.69" />
+		<PackageReference Include="NSubstitute" Version="5.1.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/IssueTracker.PlugIns.Tests.Integration/GlobalUsings.cs
+++ b/tests/IssueTracker.PlugIns.Tests.Integration/GlobalUsings.cs
@@ -28,6 +28,4 @@ global using Microsoft.Extensions.DependencyInjection;
 
 global using MongoDB.Driver;
 
-global using Testcontainers.MongoDb;
-
 global using Xunit;

--- a/tests/IssueTracker.PlugIns.Tests.Integration/IssueTracker.PlugIns.Tests.Integration.csproj
+++ b/tests/IssueTracker.PlugIns.Tests.Integration/IssueTracker.PlugIns.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -11,29 +11,27 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10"/>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.10"/>
-		<PackageReference Include="MongoDB.Driver" Version="2.21.0"/>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0"/>
-		<PackageReference Include="Testcontainers.MongoDb" Version="3.4.0"/>
-		<PackageReference Include="Testcontainers" Version="3.4.0"/>
-		<PackageReference Include="xunit" Version="2.5.0"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Testcontainers" Version="3.6.0" />
+		<PackageReference Include="Testcontainers.MongoDb" Version="3.6.0" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\CoreBusiness\IssueTracker.CoreBusiness\IssueTracker.CoreBusiness.csproj" />
 		<ProjectReference Include="..\..\src\UI\IssueTracker.UI\IssueTracker.UI.csproj" />
 		<ProjectReference Include="..\..\src\PlugIns\IssueTracker.PlugIns\IssueTracker.PlugIns.csproj" />
-		<ProjectReference Include="..\TestingSupport.Library\TestingSupport.Library.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/tests/IssueTracker.PlugIns.Tests.Integration/IssueTrackerTestFactory.cs
+++ b/tests/IssueTracker.PlugIns.Tests.Integration/IssueTrackerTestFactory.cs
@@ -7,6 +7,8 @@
 // Project Name :  IssueTracker.PlugIns.Tests.Integration
 // =============================================
 
+using Testcontainers.MongoDb;
+
 namespace IssueTracker.PlugIns;
 
 [Collection("Test collection")]

--- a/tests/IssueTracker.PlugIns.Tests.Unit/IssueTracker.PlugIns.Tests.Unit.csproj
+++ b/tests/IssueTracker.PlugIns.Tests.Unit/IssueTracker.PlugIns.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -11,15 +11,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blazored.SessionStorage" Version="2.4.0"/>
-		<PackageReference Include="Blazored.SessionStorage.TestExtensions" Version="2.4.0"/>
-		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.10"/>
-		<PackageReference Include="Moq" Version="4.20.69"/>
-		<PackageReference Include="NSubstitute" Version="5.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
-		<PackageReference Include="xunit" Version="2.5.0"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
+		<PackageReference Include="NSubstitute" Version="5.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/IssueTracker.Services.Tests.Unit/IssueTracker.Services.Tests.Unit.csproj
+++ b/tests/IssueTracker.Services.Tests.Unit/IssueTracker.Services.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -13,11 +13,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
-        <PackageReference Include="Moq" Version="4.20.69"/>
-        <PackageReference Include="xunit" Version="2.5.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+		<PackageReference Include="Moq" Version="4.20.69" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/IssueTracker.UI.Tests.Unit/IssueTracker.UI.Tests.Unit.csproj
+++ b/tests/IssueTracker.UI.Tests.Unit/IssueTracker.UI.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -11,13 +11,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <Compile Remove="ErrorModelTests.cs" />
-	  <Compile Remove="RedirectToLoginTests.cs" />
+		<Compile Remove="ErrorModelTests.cs" />
+		<Compile Remove="RedirectToLoginTests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Content Include="Pages\ErrorModelTests.cs" />
-	  <Content Include="Shared\RedirectToLoginTests.cs" />
+		<Content Include="Pages\ErrorModelTests.cs" />
+		<Content Include="Shared\RedirectToLoginTests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -28,28 +28,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Blazored.LocalStorage.TestExtensions" Version="4.4.0"/>
-        <PackageReference Include="Blazored.SessionStorage" Version="2.4.0"/>
-        <PackageReference Include="Blazored.SessionStorage.TestExtensions" Version="2.4.0"/>
-        <PackageReference Include="bunit" Version="1.22.19"/>
-		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
+		<PackageReference Include="Blazored.SessionStorage.TestExtensions" Version="2.4.0" />
+		<PackageReference Include="bunit" Version="1.25.3" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-        <PackageReference Include="Moq" Version="4.20.69"/>
-		<PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="xunit" Version="2.5.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/IssueTracker.UI.Tests.Unit/Pages/CommentTests.cs
+++ b/tests/IssueTracker.UI.Tests.Unit/Pages/CommentTests.cs
@@ -80,52 +80,52 @@ public class CommentTests : TestContext
 			"""
 			<h1 class="page-heading text-light text-uppercase mb-4">Comment on an Issue</h1>
 			<div class="issue-container">
-				<button id="create-comment" class="suggest-btn btn btn-outline-light btn-lg text-uppercase">
-					Add Comment
-				</button>
-			</div>
+							<button id="create-comment" class="suggest-btn btn btn-outline-light btn-lg text-uppercase">
+								Add Comment
+							</button>
+						</div>
 			<div class="form-layout mb-3">
-				<div class="close-button-section">
-					<button id="close-page" class="btn btn-close"></button>
-				</div>
-				<div class="issue-item-container">
-					<div class:ignore>
-						<div diff:ignore></div>
-					</div>
-					<div class="issue-entry-text">
-						<div diff:ignore></div>
-						<div diff:ignore></div>
-						<div class="issue-entry-bottom">
-							<div diff:ignore></div>
-							<div diff:ignore></div>
+						<div class="close-button-section">
+							<button id="close-page" class="btn btn-close"></button>
+						</div>
+						<div class="issue-item-container">
+							<div class="issue-entry-category issue-entry-category-clarification">
+								<div class="issue-entry-category-text">Clarification</div>
+							</div>
+							<div class="issue-entry-text">
+								<div diff:ignore></div>
+								<div diff:ignore></div>
+								<div class="issue-entry-bottom">
+									<div diff:ignore></div>
+									<div diff:ignore></div>
+								</div>
+							</div>
+							<div class="issue-entry-status issue-entry-status-inwork">
+								<div class="issue-text-status">InWork</div>
+							</div>
+						</div>
+						<div class="comment-item-container">
+							<div class="comment-vote comment-vote-none"></div>
+							<div class="comment-entry-text">
+								<form >
+									<div class="input-section">
+										<label class="form-label fw-bold text-uppercase" for="title">Title of the Comment</label>
+										<div class="input-description">Brief title of the Comment.</div>
+										<textarea id="title" name="_comment.Title" class="form-control valid"  ></textarea>
+									</div>
+									<div class="input-section">
+										<label class="form-label fw-bold text-uppercase" for="desc">Comment On the Issue</label>
+										<div class="input-description">Give, in full your comments.</div>
+										<textarea id="desc" name="_comment.Description" class="form-control valid"  ></textarea>
+									</div>
+									<div class="center-children">
+										<button id="submit-comment" class="btn btn-main btn-lg text-uppercase" type="submit">Create Comment</button>
+									</div>
+								</form>
+							</div>
+							<div class="comment-answer-status comment-answer-status-unanswered"></div>
 						</div>
 					</div>
-					<div class:ignore>
-						<div diff:ignore></div>
-					</div>
-				</div>
-				<div class="comment-item-container">
-					<div class="comment-vote comment-vote-none"></div>
-					<div class="comment-entry-text">
-						<form>
-							<div class="input-section">
-								<label class="form-label fw-bold text-uppercase" for="title">Title of the Comment</label>
-								<div class="input-description">Brief title of the Comment.</div>
-								<textarea id="title" class="form-control valid"></textarea>
-							</div>
-							<div class="input-section">
-								<label class="form-label fw-bold text-uppercase" for="desc">Comment On the Issue</label>
-								<div class="input-description">Give, in full your comments.</div>
-								<textarea id="desc" class="form-control valid"></textarea>
-							</div>
-							<div class="center-children">
-								<button id="submit-comment" class="btn btn-main btn-lg text-uppercase" type="submit">Create Comment</button>
-							</div>
-						</form>
-					</div>
-					<div class:ignore></div>
-				</div>
-			</div>
 			"""
 		);
 	}

--- a/tests/IssueTracker.UI.Tests.Unit/Pages/CreateTests.cs
+++ b/tests/IssueTracker.UI.Tests.Unit/Pages/CreateTests.cs
@@ -102,12 +102,12 @@ public class CreateTests : TestContext
 						<div class="input-section">
 							<label class="form-label fw-bold text-uppercase" for="issue-title">Issue Title</label>
 							<div class="input-description">Focus on the topic or technology you want to learn about.</div>
-							<input id="issue-title" class="form-control valid"  >
+							<input id="issue-title" name="_issue.Title" class="form-control valid"  >
 						</div>
 						<div class="input-section">
 							<label class="form-label fw-bold text-uppercase" for="description">Issue Description</label>
 							<div class="input-description">Briefly describe your suggestion.</div>
-							<textarea id="description" class="form-control valid"></textarea>
+							<textarea id="description" name="_issue.Description" class="form-control valid"></textarea>
 						</div>
 						<div class="input-section">
 							<label class="form-label fw-bold text-uppercase" for="category">Category</label>

--- a/tests/TestingSupport.Library/TestingSupport.Library.csproj
+++ b/tests/TestingSupport.Library/TestingSupport.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Configurations>Debug;Release;Test</Configurations>
@@ -21,10 +21,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-		<PackageReference Include="MongoDB.Driver" Version="2.21.0"/>
-		<PackageReference Include="MongoDB.Driver.Core" Version="2.21.0"/>
-		<PackageReference Include="Moq" Version="4.20.69"/>
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+		<PackageReference Include="Moq" Version="4.20.69" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
1. Updated the SDK version in Global.json from 7.0.0 to 8.0.0, with rollForward set to latestMinor and allowPrerelease set to false. (Global.json)
2. Updated the TargetFramework in multiple projects from net7.0 to net8.0, including IssueTracker.CoreBusiness.csproj, IssueTracker.PlugIns.csproj, IssueTracker.Services.csproj, IssueTracker.CoreBusiness.Tests.Unit.csproj, IssueTracker.PlugIns.Tests.Integration.csproj, IssueTracker.PlugIns.Tests.Unit.csproj, IssueTracker.Services.Tests.Unit.csproj, and IssueTracker.UI.Tests.Unit.csproj. (multiple files)
3. Updated the MongoDB.Bson package version in IssueTracker.CoreBusiness.csproj and IssueTracker.PlugIns.csproj from 2.21.0 to 2.22.0. (IssueTracker.CoreBusiness.csproj, IssueTracker.PlugIns.csproj)
4. Updated various package versions in multiple projects, including IssueTracker.UI.csproj, IssueTracker.CoreBusiness.Tests.Unit.csproj, IssueTracker.PlugIns.Tests.Integration.csproj, IssueTracker.PlugIns.Tests.Unit.csproj, IssueTracker.Services.Tests.Unit.csproj, and IssueTracker.UI.Tests.Unit.csproj. (multiple files)
5. Removed Testcontainers.MongoDb package reference from IssueTracker.CoreBusiness.csproj and IssueTracker.PlugIns.csproj. (IssueTracker.CoreBusiness.csproj, IssueTracker.PlugIns.csproj)
6. Updated global usings in GlobalUsings.cs by removing Testcontainers.MongoDb and adding Testcontainers.MongoDb. (GlobalUsings.cs)
7. Updated the TargetFramework in TestingSupport.Library.csproj from net7.0 to net8.0. (TestingSupport.Library.csproj)
8. Updated various package versions in TestingSupport.Library.csproj. (TestingSupport.Library.csproj)