### PR TITLE
Upgrade GitVersion from 5.x to 7.x

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4.1.0
         with:
-          versionSpec: "5.x"
+          versionSpec: "7.x"
 
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values


### PR DESCRIPTION
This pull request updates the version of GitVersion used in the `.github/workflows/dotnet.yml` workflow to ensure compatibility with newer features and improvements.

Dependency update:

* Updated the `versionSpec` for GitVersion from `"5.x"` to `"7.x"` in the workflow configuration to use the latest major version.