### PR TITLE
Change GitVersion version specification to 6.x

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4.1.0
         with:
-          versionSpec: "7.x"
+          versionSpec: "6.x"
 
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by changing the GitVersion tool version used in the `.github/workflows/dotnet.yml` file. The workflow now specifies version 6.x instead of 7.x for GitVersion.