### PR TITLE
Fix CI workflow and case sensitivity issues in .NET setup

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,11 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-      fail-fast: false
-
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
       # Test environment Auth0 configuration (dummy values for integration tests)
@@ -129,7 +124,7 @@ jobs:
                 echo "::notice::Tests passed for $proj"
               fi
             fi
-          done < <( find Tests -type f -name "*.csproj" 2>/dev/null || true )
+          done < <( find tests -type f -name "*.csproj" 2>/dev/null || true )
 
           # Fail the step if any tests failed
           if [ "$overall_rc" -ne 0 ]; then

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          global-json-file: global.json
+          global-json-file: Global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@v5


### PR DESCRIPTION
Remove the redundant strategy matrix from the CI workflow and address case sensitivity in the `global.json` filename and test project search.