### PR TITLE
Session Log: 2026-02-17 — Resolved Copilot CLI Tool Configuration

### DIFF
--- a/.ai-team/agents/wong/history.md
+++ b/.ai-team/agents/wong/history.md
@@ -18,6 +18,10 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+📌 **Skill Structure Standardization (2026-02-16):** All skills must follow the directory pattern `{skill-name}/SKILL.md`, not loose `.md` files at the skills directory level. Each SKILL.md file must include YAML frontmatter with `name`, `description`, `domain`, `confidence`, and `source` fields. This prevents tool name collisions and maintains consistency across the squad. — decided by Wong
+
+📌 **Tool Name Uniqueness:** Skill names (from YAML frontmatter `name` field) and MCP server names must not overlap. During infrastructure setup, audit all `.ai-team/skills/*/SKILL.md` files and `.copilot/mcp-config.json` for naming conflicts before deploying changes. — decided by Wong
+
 📌 Milestone release changelog template: Section headers (Features Delivered, Issues Resolved, Test Coverage, Breaking Changes), bulleted feature lists with issue references, test metrics summary — use this for future release documentation — decided by Wong
 
 📌 Team update (2026-02-10): NuGet packages blocked — no CI/CD pipeline exists, must be created — decided by Shuri

--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -461,3 +461,52 @@ AppHost
 **What:** When creating new projects, all package references must follow CPM patterns — no version specifications in project files. All versions managed centrally in `Directory.Packages.props`.
 
 **Why:** User preference for consistency and centralized version control across the solution.
+
+---
+
+## 2026-02-16: Skill Structure and Tool Naming Standardization
+
+**By:** Wong  
+**Context:** "tools: Tool names must be unique" error from Copilot CLI during skill configuration.
+
+### What Was Fixed
+
+1. **Skill Directory Structure:**
+   - Moved misplaced `auth0-integration.md` from `.ai-team/skills/` → `.ai-team/skills/auth0-integration/SKILL.md`
+   - Verified all skills follow the pattern: `{skill-name}/SKILL.md` (not loose `.md` files)
+
+2. **YAML Frontmatter Standardization:**
+   - Added YAML metadata header to `auth0-integration/SKILL.md` with unique name
+   - All three skills now have consistent frontmatter:
+     - `name:` — unique identifier (lowercase, hyphenated)
+     - `description:` — clear purpose statement
+     - `domain:` — functional category
+     - `confidence:` — observation maturity level
+     - `source:` — how skill was documented
+
+3. **Tool Name Audit:**
+   - Discovered skill names: `auth0-integration`, `post-build-validation`, `webapp-testing`
+   - Discovered MCP server names: `EXAMPLE-trello`
+   - **Result:** No duplicates or conflicts
+
+### Why This Matters
+
+- Copilot CLI requires unique tool/skill names across all configs
+- Inconsistent directory structure (loose `.md` files vs subdirectories) breaks tooling expectations
+- YAML frontmatter enables skill discovery and prevents collisions
+- This pattern is reusable across all future squad projects
+
+### Documentation
+
+**Pattern for Infrastructure Teams:**
+- Skills live in `.ai-team/skills/{skill-name}/SKILL.md`
+- Every `SKILL.md` must include YAML header with `name` field
+- Before onboarding new skills, audit against existing skill names and MCP server names
+- Use lowercase, hyphenated naming: `skill-name`, not `SkillName` or `skill_name`
+
+### Verification
+
+✓ Copilot CLI `--version` runs without "tools must be unique" error  
+✓ All skills have valid YAML frontmatter  
+✓ No tool name collisions between skills and MCP servers  
+✓ Directory structure is now consistent across `.ai-team/skills/`

--- a/.ai-team/skills/auth0-integration/SKILL.md
+++ b/.ai-team/skills/auth0-integration/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: "auth0-integration"
+description: "Auth0 OAuth2/OpenID Connect integration for Blazor + ASP.NET Core with JWT validation, role-based authorization, and secure token management"
+domain: "authentication, authorization, security"
+confidence: "medium"
+source: "earned"
+---
+
 # Auth0 Integration Skill — IssueTracker Backend & Frontend
 
 ## Overview


### PR DESCRIPTION
Wong fixed the "tools: Tool names must be unique" error by:
- Restructuring .ai-team/skills/auth0-integration/ (moved from loose file to proper subdirectory)
- Adding standardized YAML frontmatter with unique 'name' fields to all skill definitions
- Auditing tool names across skills and MCP servers (zero conflicts found)

Result: Copilot CLI operational. No remaining blockers.

Status: Complete ✓

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>