### PR TITLE
chore: migrate ai-team references to squad

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -62,11 +62,6 @@
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
 # Squad: union merge for append-only team state files
-.ai-team/decisions.md merge=union
-.ai-team/agents/*/history.md merge=union
-.ai-team/log/** merge=union
-.ai-team/orchestration-log/** merge=union
-# Squad: union merge for append-only team state files
 .squad/decisions.md merge=union
 .squad/agents/*/history.md merge=union
 .squad/log/** merge=union

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -28,9 +28,9 @@ jobs:
             const memberName = label.replace('squad:', '').toLowerCase();
 
             // Read team roster to find the member
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              core.warning('No .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -69,7 +69,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.ai-team/team.md\` for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/.github/workflows/squad-main-guard.yml
+++ b/.github/workflows/squad-main-guard.yml
@@ -41,8 +41,8 @@ jobs:
               .filter(f => f.status !== 'removed')
               .map(f => f.filename)
               .filter(f => {
-                // .ai-team/** — ALL team state files, zero exceptions
-                if (f === '.ai-team' || f.startsWith('.ai-team/')) return true;
+                // .squad/** — ALL team state files, zero exceptions
+                if (f === '.squad' || f.startsWith('.squad/')) return true;
                 // team-docs/** — ALL internal team docs, zero exceptions
                 if (f.startsWith('team-docs/')) return true;
                 return false;
@@ -58,7 +58,7 @@ jobs:
               '## 🚫 Forbidden files detected in PR to main',
               '',
               'The following files must NOT be merged into `main`.',
-              '`.ai-team/` is runtime team state — it belongs on dev branches only.',
+              '`.squad/` is runtime team state — it belongs on dev branches only.',
               '`team-docs/` is internal team content — it belongs on dev branches only.',
               '',
               '### Forbidden files found:',
@@ -68,8 +68,8 @@ jobs:
               '### How to fix:',
               '',
               '```bash',
-              '# Remove tracked .ai-team/ files (keeps local copies):',
-              'git rm --cached -r .ai-team/',
+              '# Remove tracked .squad/ files (keeps local copies):',
+              'git rm --cached -r .squad/',
               '',
               '# Remove tracked team-docs/ files:',
               'git rm --cached -r team-docs/',
@@ -79,7 +79,7 @@ jobs:
               'git push',
               '```',
               '',
-              '> ⚠️ `.ai-team/` is committed on `dev` and feature branches by design.',
+              '> ⚠️ `.squad/` is committed on `dev` and feature branches by design.',
               '> The guard workflow is the enforcement mechanism that keeps these files off `main` and `preview`.',
               '> `git rm --cached` untracks them from this PR without deleting your local copies.',
             ];

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -23,9 +23,9 @@ jobs:
             const issue = context.payload.issue;
 
             // Read team roster to find the Lead and all members
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              core.warning('No .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -86,7 +86,7 @@ jobs:
             }
 
             // Read routing rules
-            const routingFile = '.ai-team/routing.md';
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -3,7 +3,7 @@ name: Sync Squad Labels
 on:
   push:
     paths:
-      - '.ai-team/team.md'
+      - '.squad/team.md'
   workflow_dispatch:
 
 permissions:
@@ -21,10 +21,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
 
             if (!fs.existsSync(teamFile)) {
-              core.info('No .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 

--- a/.squad/agents/hawkeye/charter.md
+++ b/.squad/agents/hawkeye/charter.md
@@ -37,10 +37,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/hawkeye-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/hawkeye-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/mantis/charter.md
+++ b/.squad/agents/mantis/charter.md
@@ -33,10 +33,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/mantis-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/mantis-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/nebula/charter.md
+++ b/.squad/agents/nebula/charter.md
@@ -34,10 +34,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/nebula-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/nebula-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/nebula/history.md
+++ b/.squad/agents/nebula/history.md
@@ -73,7 +73,7 @@
  Team update (2026-02-11): All plans must be tracked as GitHub issues and milestones; each sprint is a milestone  decided by Jeffrey T. Fritz
  Team update (2026-02-11): Boss bar title now configurable via WithBossBar(title) parameter and ASPIRE_BOSSBAR_TITLE env var; ASPIRE_APP_NAME no longer affects boss bar  decided by Rocket
  Team update (2026-02-11): Village structures now use idempotent build pattern (build once, then only update health indicators)  decided by Rocket
-� Team update (2026-02-11): CI pipelines now skip docs-only changes (docs/**, user-docs/**, *.md, .ai-team/**)  decided by Wong
+� Team update (2026-02-11): CI pipelines now skip docs-only changes (docs/**, user-docs/**, *.md, .squad/**)  decided by Wong
 
 📌 Team update (2026-02-15): Structural validation requirements — all acceptance tests must verify door accessibility, staircase connectivity, and wall-mounted items. Created 76 new fill-overlap detection tests (20), RCON block verification tests (56), fixed 5 integration test files. — decided by Jeff (Jeffrey T. Fritz)
 

--- a/.squad/agents/rhodey/charter.md
+++ b/.squad/agents/rhodey/charter.md
@@ -34,10 +34,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/rhodey-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/rhodey-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/rhodey/history.md
+++ b/.squad/agents/rhodey/history.md
@@ -45,7 +45,7 @@
 - **Documentation placement rationale**: Both files in docs/ root for high visibility. architecture-diagram.md is educational (helps contributors understand), minecraft-constraints.md is prescriptive (enforces consistency). Together they form complete reference for world-building features.
  Team update (2026-02-11): All sprints must include README and user documentation updates to be considered complete  decided by Jeffrey T. Fritz
  Team update (2026-02-11): All plans must be tracked as GitHub issues and milestones; each sprint is a milestone  decided by Jeffrey T. Fritz
-� Team update (2026-02-11): CI pipelines now skip docs-only changes (docs/**, user-docs/**, *.md, .ai-team/**)  decided by Wong
+� Team update (2026-02-11): CI pipelines now skip docs-only changes (docs/**, user-docs/**, *.md, .squad/**)  decided by Wong
  Team update (2026-02-11): 14 user-facing docs now live in user-docs/ with consistent structure (What  How  What You'll See  Use Cases  Code Example)  decided by Vision
 
 ### 2026-02-11: Sprint 4 Planning Analysis
@@ -60,7 +60,7 @@
 ### 2026-02-12: Sprint 4 Brainstorming — Aspire Observability Visualization Ideas
 
 - **Jeff's request:** "What would be fun to browse and wander around in Minecraft? Some way to visualize traces?" — Jeff is looking to go beyond resource health into OpenTelemetry observability data (traces, metrics, logs).
-- **10 ideas brainstormed**, ranging from Easy to Hard feasibility. Full write-up in `.ai-team/decisions/inbox/rhodey-sprint4-visualization-ideas.md`.
+- **10 ideas brainstormed**, ranging from Easy to Hard feasibility. Full write-up in `.squad/decisions/inbox/rhodey-sprint4-visualization-ideas.md`.
 - **Top 3 for Sprint 4 (no new data source needed):** Dragon Health Egg (SLO visualization with Ender Dragon theming), Redstone Clock Dashboard (time-series health display), Sculk Error Network (cascading failure visualization using Deep Dark blocks).
 - **Jeff's trace interest → Trace River is the headline feature for Sprint 5.** Water channels between buildings with boats representing requests, lava for errors. Requires OTLP trace ingestion — a new architectural capability the worker doesn't have today.
 - **Critical architectural decision identified:** All OTLP-dependent features (7 of 10 ideas) require the worker to consume trace/metric/log data. Today it only polls health endpoints. Must design the OTLP ingestion architecture before committing to any individual feature. Three options documented: secondary OTLP receiver, Aspire dashboard API polling, or shared collector.
@@ -75,8 +75,8 @@
 - **Sprint 4 scoped to 14 issues:** 4 dashboard, 3 enhanced buildings, 1 Dragon Egg, 3 DX polish (WithAllFeatures, env var tightening, welcome teleport), 3 documentation (README, user-docs, tests). Cut line: welcome teleport drops first, then Dragon Egg.
 - **Key design principle:** Azure detection is a visual signal (banner), not an architectural integration. String matching on resource types keeps the main package free of Azure SDK dependencies, consistent with the separate-package decision from Sprint 2.
 - **Cylinder RCON cost is ~88 commands** (4× a watchtower) due to circular geometry. Acceptable as one-time build; databases are typically <30% of resources.
-- **Decisions logged** in `.ai-team/decisions/inbox/rhodey-sprint4-design.md` (7 decisions).
-- **Decisions logged** in `.ai-team/decisions/inbox/rhodey-sprint4-design.md` (7 decisions).
+- **Decisions logged** in `.squad/decisions/inbox/rhodey-sprint4-design.md` (7 decisions).
+- **Decisions logged** in `.squad/decisions/inbox/rhodey-sprint4-design.md` (7 decisions).
 
 ### 2026-02-12: BlueMap Integration Testing Strategy Design
 
@@ -100,7 +100,7 @@
 - **Rails coexist with redstone, not replace.** `WithMinecartRails()` runs alongside `WithRedstoneDependencyGraph()` with 1-block X offset. Both visual systems provide different information: redstone shows health reactivity, rails show physical connection.
 - **Grand Village is opt-in** via `WithGrandVillage()`. Standard 7×7 layout remains the default. No breaking changes for existing consumers.
 - **15 GitHub issues created** (#76-90) covering: layout foundation, extension methods, 6 building redesigns, rail service, burst mode, fence/paths/forceload, service adaptation, tests, documentation, and release prep.
-- **7 architectural decisions logged** in `.ai-team/decisions/inbox/rhodey-sprint5-grand-village.md`.
+- **7 architectural decisions logged** in `.squad/decisions/inbox/rhodey-sprint5-grand-village.md`.
 - **Key risk: Grand Silo (radius 7 cylinder) at ~130 commands** is the most expensive building due to circular geometry not being `/fill`-friendly. Octagonal approximation may reduce by ~30%.
 - **Phased plan:** Phase 1 Layout (Shuri), Phase 2 Buildings (Rocket, 3 parallel tracks), Phase 3 Rails (Rocket), Phase 4 Tests/Docs (Nebula/Rhodey), Phase 5 Polish (Rhodey). ~2 weeks total with parallel execution.
 
@@ -119,7 +119,7 @@
 - **Building models are pure C#, one file per building.** Located in `src/Aspire.Hosting.Minecraft.Worker/Services/FamousBuildingModels/`. Implements `IFamousBuildingModel` interface with `Width`, `Depth`, `Height`, and `BuildAsync()`. Shared geometry helpers in `BuildingHelpers.cs`.
 - **FamousBuilding enum has 15 members** spanning 6 continents. All constrained to 15×15 footprint, 200 RCON command cap. Requires `WithGrandVillage()` — falls back to auto-detection on 7×7 grid.
 - **Two-sprint phasing:** Sprint A = API + infrastructure + 3 starter models (Pyramid, Castle, Lighthouse). Sprint B = remaining 12 models. Depends on Sprint 5 Grand Village layout landing first.
-- **Design document:** `docs/designs/famous-buildings-design.md`. Decision log: `.ai-team/decisions/inbox/rhodey-famous-buildings-design.md`.
+- **Design document:** `docs/designs/famous-buildings-design.md`. Decision log: `.squad/decisions/inbox/rhodey-famous-buildings-design.md`.
 - **Key files:** `FamousBuilding.cs` (enum), `FamousBuildingAnnotation.cs` (annotation), `FamousBuildingExtensions.cs` (extension method) — all in `src/Aspire.Hosting.Minecraft/`.
 
 ### 2026-02-12: MonitorAllResources Convenience API — Architecture Design
@@ -129,7 +129,7 @@
 - **ExcludeFromMonitoring ships alongside.** Annotation-based opt-out via `ExcludeFromMonitoringAnnotation` — trivial to implement (1 annotation class + 1 extension method + 1 line in exclusion check) and completes the user story.
 - **Naming: `MonitorAllResources()` not `WithAllMonitoredResources()`.** Breaks the `With*` convention intentionally — it's a convenience aggregate, not a feature toggle. The verb phrase reads naturally and distinguishes it from the per-resource method.
 - **Duplicate prevention is bidirectional.** `MonitoredResourceNames.Contains()` check prevents duplicates when manual calls precede `MonitorAllResources()`. Calls after are additive and safe (env vars are idempotent).
-- **Design document:** `docs/designs/monitor-all-resources-design.md`. Decision: `.ai-team/decisions/inbox/rhodey-monitor-all-resources.md`.
+- **Design document:** `docs/designs/monitor-all-resources-design.md`. Decision: `.squad/decisions/inbox/rhodey-monitor-all-resources.md`.
  Team update (2026-02-12): Sprint 5 Grand Village architecture designed  VillageLayout constants become mutable properties, structure size increases to 1515 (1313 usable interior), spacing becomes 24 blocks (15 + 9 gap for rails/paths), MAX_WORLD_SIZE increases to 512, RCON burst mode (1040 cmd/s during build), minecart rails coexist with redstone wires, opt-in via WithGrandVillage()  decided by Rhodey
  Team update (2026-02-12): Famous Buildings API designed  AsMinecraftFamousBuilding(FamousBuilding enum), 15 iconic buildings (geographic diversity), pure C# build models, annotation-based with env var flow, requires WithGrandVillage(), 200 RCON command max per building, two-sprint phasing (3 buildings in Sprint A, 12 remaining in Sprint B)  decided by Rhodey
  Team update (2026-02-12): MonitorAllResources convenience API design approved  .MonitorAllResources() extension auto-discovers all non-Minecraft resources, ExcludeFromMonitoring() opt-out, eliminates manual WithMonitoredResource() calls, eager discovery, Famous Building annotations pass through  decided by Rhodey
@@ -149,7 +149,7 @@
 - **5 integration test failures are expected** — they require a running Minecraft Docker container. The `--filter "Category!=Integration"` doesn't exclude them because integration tests are missing `[Trait("Category", "Integration")]` — they use `[Collection("Minecraft")]` instead. Non-blocking, filed as observation.
 - **NuGet package created:** `Fritz.Aspire.Hosting.Minecraft.0.1.0-dev.nupkg` (~39.6 MB). Package validation passed. Version set to `0.5.0` at release time via CI pipeline `-p:Version` override.
 - **Three non-blocking observations for future work:** (1) Add `[Trait("Category", "Integration")]` to integration tests. (2) Fix CS8604 nullable warning. (3) Confirm CI sets correct version from git tag.
-- **Release decision:** APPROVED — written to `.ai-team/decisions/inbox/rhodey-v050-release-ready.md`.
+- **Release decision:** APPROVED — written to `.squad/decisions/inbox/rhodey-v050-release-ready.md`.
 
 📌 Team update (2026-02-13): v0.5.0 release readiness APPROVED — 35 public methods, 434 tests pass, build clean, package verified, 3 non-blocking observations documented — decided by Rhodey
 
@@ -157,7 +157,7 @@
 
 ### 2026-02-15: MCA Inspector Milestone Planned
 
-- **Milestone document created** at `.ai-team/decisions/inbox/rhodey-mca-inspector-milestone.md` — comprehensive plan for reading Minecraft Anvil region files directly to verify block state.
+- **Milestone document created** at `.squad/decisions/inbox/rhodey-mca-inspector-milestone.md` — comprehensive plan for reading Minecraft Anvil region files directly to verify block state.
 - **Goal:** Bypass RCON for bulk structure verification. Today's tests make 225+ RCON calls to verify one 15×15 watchtower; MCA inspector will query all blocks from disk in <1 second.
 - **Architecture:** New optional NuGet package `Aspire.Hosting.Minecraft.Anvil` (separate from main, keeps main free of NBT dependencies). AnvilRegionReader class provides `GetBlockAt(x, y, z)` API.
 - **Four phases planned:** (1) Library + NBT selection (~4 days), (2) Test fixture integration (~2 days), (3) Bulk verification tests (~3 days), (4) Polish + docs (~1 day). Total ~1.5 weeks with 1 FTE.

--- a/.squad/agents/rocket/charter.md
+++ b/.squad/agents/rocket/charter.md
@@ -33,10 +33,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/rocket-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/rocket-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -11,18 +11,18 @@
 
 ## What I Own
 
-- `.ai-team/log/` — session logs (what happened, who worked, what was decided)
-- `.ai-team/decisions.md` — the shared decision log all agents read (canonical, merged)
-- `.ai-team/decisions/inbox/` — decision drop-box (agents write here, I merge)
+- `.squad/log/` — session logs (what happened, who worked, what was decided)
+- `.squad/decisions.md` — the shared decision log all agents read (canonical, merged)
+- `.squad/decisions/inbox/` — decision drop-box (agents write here, I merge)
 - Cross-agent context propagation — when one agent's decision affects another
 
 ## How I Work
 
-**Worktree awareness:** Use the `TEAM ROOT` provided in the spawn prompt to resolve all `.ai-team/` paths. If no TEAM ROOT is given, run `git rev-parse --show-toplevel` as fallback. Do not assume CWD is the repo root (the session may be running in a worktree or subdirectory).
+**Worktree awareness:** Use the `TEAM ROOT` provided in the spawn prompt to resolve all `.squad/` paths. If no TEAM ROOT is given, run `git rev-parse --show-toplevel` as fallback. Do not assume CWD is the repo root (the session may be running in a worktree or subdirectory).
 
 After every substantial work session:
 
-1. **Log the session** to `.ai-team/log/{YYYY-MM-DD}-{topic}.md`:
+1. **Log the session** to `.squad/log/{YYYY-MM-DD}-{topic}.md`:
    - Who worked
    - What was done
    - Decisions made
@@ -31,8 +31,8 @@ After every substantial work session:
 
 2. **Merge the decision inbox:**
 
-   - Read all files in `.ai-team/decisions/inbox/`
-   - APPEND each decision's contents to `.ai-team/decisions.md`
+   - Read all files in `.squad/decisions/inbox/`
+   - APPEND each decision's contents to `.squad/decisions.md`
    - Delete each inbox file after merging
 
 3. **Deduplicate and consolidate decisions.md:**
@@ -49,14 +49,14 @@ After every substantial work session:
    📌 Team update ({date}): {summary} — decided by {Name}
 ```text
 
-5. **Commit `.ai-team/` changes** using Windows-compatible git commands.
+5. **Commit `.squad/` changes** using Windows-compatible git commands.
 
 6. **Never speak to the user.** Never appear in responses. Work silently.
 
 ## The Memory Architecture
 
 ```text
-.ai-team/
+.squad/
 ├── decisions.md          # Shared brain — all agents read this (merged by Scribe)
 ├── decisions/
 │   └── inbox/            # Drop-box — agents write decisions here in parallel

--- a/.squad/agents/shuri/charter.md
+++ b/.squad/agents/shuri/charter.md
@@ -32,10 +32,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/shuri-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/shuri-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/vision/charter.md
+++ b/.squad/agents/vision/charter.md
@@ -34,10 +34,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/vision-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/vision-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/wong/charter.md
+++ b/.squad/agents/wong/charter.md
@@ -34,10 +34,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/wong-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/wong-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/agents/wong/history.md
+++ b/.squad/agents/wong/history.md
@@ -11,7 +11,7 @@
 - Version 0.1.0, packed via `dotnet pack -o nupkgs`
 - GitHub repo: csharpfritz/Aspire-Minecraft
 - No CI/CD pipeline exists yet (no .github/workflows/ found)
-- .gitattributes configured for merge=union on .ai-team/ files
+- .gitattributes configured for merge=union on .squad/ files
 - MIT licensed
 
 ## Learnings
@@ -20,7 +20,7 @@
 
 📌 **Skill Structure Standardization (2026-02-16):** All skills must follow the directory pattern `{skill-name}/SKILL.md`, not loose `.md` files at the skills directory level. Each SKILL.md file must include YAML frontmatter with `name`, `description`, `domain`, `confidence`, and `source` fields. This prevents tool name collisions and maintains consistency across the squad. — decided by Wong
 
-📌 **Tool Name Uniqueness:** Skill names (from YAML frontmatter `name` field) and MCP server names must not overlap. During infrastructure setup, audit all `.ai-team/skills/*/SKILL.md` files and `.copilot/mcp-config.json` for naming conflicts before deploying changes. — decided by Wong
+📌 **Tool Name Uniqueness:** Skill names (from YAML frontmatter `name` field) and MCP server names must not overlap. During infrastructure setup, audit all `.squad/skills/*/SKILL.md` files and `.copilot/mcp-config.json` for naming conflicts before deploying changes. — decided by Wong
 
 📌 Milestone release changelog template: Section headers (Features Delivered, Issues Resolved, Test Coverage, Breaking Changes), bulleted feature lists with issue references, test metrics summary — use this for future release documentation — decided by Wong
 
@@ -118,13 +118,13 @@
 **Changes:**
 
 - Added `paths-ignore` filters to all three GitHub Actions workflows (build.yml, release.yml, codeql.yml) to skip builds/tests/analysis when only documentation changes.
-- Ignored paths: `docs/**`, `user-docs/**`, `*.md` (root-level markdown), `.ai-team/**` (squad state).
+- Ignored paths: `docs/**`, `user-docs/**`, `*.md` (root-level markdown), `.squad/**` (squad state).
 - Applied to both `push` and `pull_request` triggers for build.yml and codeql.yml. Applied to `push.tags` in release.yml for completeness (unlikely scenario but prevents accidental doc-only tag releases).
 
 **Key decisions:**
 
 - Documentation updates (README, CONTRIBUTING, docs/, user-docs/) don't require CI build/test/pack cycles — they don't affect code correctness or package output.
-- The `.ai-team/**` folder contains squad-internal state and decisions, also irrelevant to builds.
+- The `.squad/**` folder contains squad-internal state and decisions, also irrelevant to builds.
 - Root-level `*.md` pattern catches README.md, CONTRIBUTING.md, etc. but not markdown files in subdirectories (those would be caught by `docs/**` or `user-docs/**` as appropriate).
 - The scheduled CodeQL run (Monday 06:25 UTC) is unaffected by path filters — it always runs on schedule regardless of recent commits.
  Team update (2026-02-11): All sprints must include README and user documentation updates to be considered complete  decided by Jeffrey T. Fritz

--- a/.squad/templates/scribe-charter.md
+++ b/.squad/templates/scribe-charter.md
@@ -92,7 +92,7 @@ After every substantial work session:
    - Write the commit message to a temp file, then commit with `-F`:
 ```bash
      $msg = @"
-     docs(ai-team): {brief summary}
+     docs(squad): {brief summary}
 
      Session: {timestamp}-{topic}
      Requested by: {user name}

--- a/.squad/templates/skills/windows-compatibility/SKILL.md
+++ b/.squad/templates/skills/windows-compatibility/SKILL.md
@@ -67,7 +67,7 @@ cd $teamRoot
 git add .squad/
 if ($LASTEXITCODE -eq 0) {
   $msg = @"
-docs(ai-team): session log
+docs(squad): session log
 
 Changes:
 - Added decisions

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -21,7 +21,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+Check: Does `.squad/team.md` exist? (fall back to `.squad/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -628,7 +628,7 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
-3. Check if `.squad/` exists at that root (fall back to `.ai-team/` for repos that haven't migrated yet).
+3. Check if `.squad/` exists at that root (fall back to `.squad/` for repos that haven't migrated yet).
    - **Yes** → use **worktree-local** strategy. Team root = current worktree root.
    - **No** → use **main-checkout** strategy. Discover the main working tree:
      ```

--- a/.squad/templates/workflows/squad-heartbeat.yml
+++ b/.squad/templates/workflows/squad-heartbeat.yml
@@ -106,10 +106,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            let teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) return;
 
             const content = fs.readFileSync(teamFile, 'utf8');
@@ -154,7 +151,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/.squad/templates/workflows/squad-issue-assign.yml
+++ b/.squad/templates/workflows/squad-issue-assign.yml
@@ -27,13 +27,10 @@ jobs:
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            // Read team roster
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -72,7 +69,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` (or \`.ai-team/team.md\`) for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/.squad/templates/workflows/squad-preview.yml
+++ b/.squad/templates/workflows/squad-preview.yml
@@ -29,13 +29,9 @@ jobs:
       - name: Run tests
         run: node --test test/*.test.cjs
 
-      - name: Check no .ai-team/ or .squad/ files are tracked
+      - name: Check no .squad/ files are tracked
         run: |
           FOUND_FORBIDDEN=0
-          if git ls-files --error-unmatch .ai-team/ 2>/dev/null; then
-            echo "::error::❌ .ai-team/ files are tracked on preview — this must not ship."
-            FOUND_FORBIDDEN=1
-          fi
           if git ls-files --error-unmatch .squad/ 2>/dev/null; then
             echo "::error::❌ .squad/ files are tracked on preview — this must not ship."
             FOUND_FORBIDDEN=1
@@ -43,7 +39,7 @@ jobs:
           if [ $FOUND_FORBIDDEN -eq 1 ]; then
             exit 1
           fi
-          echo "✅ No .ai-team/ or .squad/ files tracked — clean for release."
+          echo "✅ No .squad/ files tracked — clean for release."
 
       - name: Validate package.json version
         run: |

--- a/.squad/templates/workflows/squad-promote.yml
+++ b/.squad/templates/workflows/squad-promote.yml
@@ -36,7 +36,7 @@ jobs:
           echo "=== dev HEAD ===" && git log origin/dev -1 --oneline
           echo "=== preview HEAD ===" && git log origin/preview -1 --oneline
           echo "=== Files that would be stripped ==="
-          git diff origin/preview..origin/dev --name-only | grep -E "^(\.(ai-team|squad|ai-team-templates)|team-docs/|docs/proposals/)" || echo "(none)"
+          git diff origin/preview..origin/dev --name-only | grep -E "^(\.(squad|squad-templates)|team-docs/|docs/proposals/)" || echo "(none)"
 
       - name: Merge dev → preview (strip forbidden paths)
         if: ${{ inputs.dry_run == 'false' }}
@@ -46,9 +46,8 @@ jobs:
 
           # Strip forbidden paths from merge commit
           git rm -rf --cached --ignore-unmatch \
-            .ai-team/ \
             .squad/ \
-            .ai-team-templates/ \
+            .squad-templates/ \
             team-docs/ \
             "docs/proposals/" || true
 
@@ -100,7 +99,7 @@ jobs:
           echo "✅ Version $VERSION has CHANGELOG entry"
 
           # Verify no forbidden files on preview
-          FORBIDDEN=$(git ls-files | grep -E "^(\.(ai-team|squad|ai-team-templates)/|team-docs/|docs/proposals/)" || true)
+          FORBIDDEN=$(git ls-files | grep -E "^(\.(squad|squad-templates)/|team-docs/|docs/proposals/)" || true)
           if [ -n "$FORBIDDEN" ]; then
             echo "::error::Forbidden files found on preview: $FORBIDDEN"
             exit 1

--- a/.squad/templates/workflows/squad-triage.yml
+++ b/.squad/templates/workflows/squad-triage.yml
@@ -22,13 +22,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            // Read team roster
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -88,11 +85,8 @@ jobs:
               }
             }
 
-            // Read routing rules — check .squad/ first, fall back to .ai-team/
-            let routingFile = '.squad/routing.md';
-            if (!fs.existsSync(routingFile)) {
-              routingFile = '.ai-team/routing.md';
-            }
+            // Read routing rules
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/.squad/templates/workflows/sync-squad-labels.yml
+++ b/.squad/templates/workflows/sync-squad-labels.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - '.squad/team.md'
-      - '.ai-team/team.md'
   workflow_dispatch:
 
 permissions:
@@ -22,13 +21,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-
-            if (!fs.existsSync(teamFile)) {
-              core.info('No .squad/team.md or .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 


### PR DESCRIPTION
## Summary
- replace remaining `.ai-team` references with `.squad`
- update active and template workflows to use squad paths
- clean duplicate fallback/path entries introduced during migration

## Notes
- branch includes workflow, template, and squad metadata updates only