### PR TITLE
chore: migrate workflow ai-team references to squad

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -62,11 +62,6 @@
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
 # Squad: union merge for append-only team state files
-.ai-team/decisions.md merge=union
-.ai-team/agents/*/history.md merge=union
-.ai-team/log/** merge=union
-.ai-team/orchestration-log/** merge=union
-# Squad: union merge for append-only team state files
 .squad/decisions.md merge=union
 .squad/agents/*/history.md merge=union
 .squad/log/** merge=union

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -28,9 +28,9 @@ jobs:
             const memberName = label.replace('squad:', '').toLowerCase();
 
             // Read team roster to find the member
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              core.warning('No .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -69,7 +69,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.ai-team/team.md\` for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/.github/workflows/squad-main-guard.yml
+++ b/.github/workflows/squad-main-guard.yml
@@ -41,8 +41,8 @@ jobs:
               .filter(f => f.status !== 'removed')
               .map(f => f.filename)
               .filter(f => {
-                // .ai-team/** — ALL team state files, zero exceptions
-                if (f === '.ai-team' || f.startsWith('.ai-team/')) return true;
+                // .squad/** — ALL team state files, zero exceptions
+                if (f === '.squad' || f.startsWith('.squad/')) return true;
                 // team-docs/** — ALL internal team docs, zero exceptions
                 if (f.startsWith('team-docs/')) return true;
                 return false;
@@ -58,7 +58,7 @@ jobs:
               '## 🚫 Forbidden files detected in PR to main',
               '',
               'The following files must NOT be merged into `main`.',
-              '`.ai-team/` is runtime team state — it belongs on dev branches only.',
+              '`.squad/` is runtime team state — it belongs on dev branches only.',
               '`team-docs/` is internal team content — it belongs on dev branches only.',
               '',
               '### Forbidden files found:',
@@ -68,8 +68,8 @@ jobs:
               '### How to fix:',
               '',
               '```bash',
-              '# Remove tracked .ai-team/ files (keeps local copies):',
-              'git rm --cached -r .ai-team/',
+              '# Remove tracked .squad/ files (keeps local copies):',
+              'git rm --cached -r .squad/',
               '',
               '# Remove tracked team-docs/ files:',
               'git rm --cached -r team-docs/',
@@ -79,7 +79,7 @@ jobs:
               'git push',
               '```',
               '',
-              '> ⚠️ `.ai-team/` is committed on `dev` and feature branches by design.',
+              '> ⚠️ `.squad/` is committed on `dev` and feature branches by design.',
               '> The guard workflow is the enforcement mechanism that keeps these files off `main` and `preview`.',
               '> `git rm --cached` untracks them from this PR without deleting your local copies.',
             ];

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -23,9 +23,9 @@ jobs:
             const issue = context.payload.issue;
 
             // Read team roster to find the Lead and all members
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              core.warning('No .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -86,7 +86,7 @@ jobs:
             }
 
             // Read routing rules
-            const routingFile = '.ai-team/routing.md';
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -3,7 +3,7 @@ name: Sync Squad Labels
 on:
   push:
     paths:
-      - '.ai-team/team.md'
+      - '.squad/team.md'
   workflow_dispatch:
 
 permissions:
@@ -21,10 +21,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const teamFile = '.ai-team/team.md';
+            const teamFile = '.squad/team.md';
 
             if (!fs.existsSync(teamFile)) {
-              core.info('No .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 


### PR DESCRIPTION
## Summary
- migrate workflow/config references from `.ai-team` to `.squad`
- update protected-branch guard messaging and path checks
- keep PR main-safe by excluding runtime `.squad/**` state files

## Supersedes
- Replaces #100 for merge into `main`